### PR TITLE
Hana kyle redirect

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,4 +1,4 @@
-from flask import render_template
+from flask import render_template, redirect
 from flask_login import login_required
 from ..models import EditableHTML
 from . import main
@@ -21,9 +21,7 @@ def about():
 
 @main.route('/resources')
 def resources():
-    editable_html_obj = EditableHTML.get_editable_html('resources')
-    return render_template(
-        'main/resources.html', editable_html_obj=editable_html_obj)
+    return redirect("http://www.nextgenerationscholars.org")
 
 
 @main.route('/calendar', methods=['GET', 'POST'])

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -6,10 +6,38 @@
     <div class="twelve wide computer sixteen wide mobile column">
         <div class="row">
             {{ page.render_inline_editor(editable_html_obj, current_user) }}
-            <iframe src="http://ngsapp.strikingly.com/" width="900" height="450"></iframe>
+            <div class="intrinsic-container intrinsic-container-16x9">
+            	<iframe src="http://ngsapp.strikingly.com/" ></iframe>
+            <div>
         </div>
     </div>
 </div>
 
 <script src="{{ url_for('static', filename='ckeditor/ckeditor.js') }}"></script>
+<!-- script handles rendering the iFrame for mobile/desktop -->
+<style type="text/css">
+.intrinsic-container {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+}
+ 
+/* 16x9 Aspect Ratio */
+.intrinsic-container-16x9 {
+  padding-bottom: 56.25%;
+}
+ 
+/* 4x3 Aspect Ratio */
+.intrinsic-container-4x3 {
+  padding-bottom: 75%;
+}
+ 
+.intrinsic-container iframe {
+  position: absolute;
+  top:0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+</style>
 {% endblock %}

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -5,8 +5,8 @@
 <div class="ui stackable grid centered container" style="margin-top:12px; margin-bottom:64px">
     <div class="twelve wide computer sixteen wide mobile column">
         <div class="row">
-            <h1 class="ui dividing header">Welcome to Next Generation Scholars</h1>
             {{ page.render_inline_editor(editable_html_obj, current_user) }}
+            <iframe src="http://ngsapp.strikingly.com/" width="900" height="450"></iframe>
         </div>
     </div>
 </div>


### PR DESCRIPTION
A quick demo that I showed Kyle, here as a reference for future developers! Includes 1) a mobile-responsive iFrame on the index page which shows an explanation of the site (see ngsapp.strikingly.com) and 2) the "resources" navbar item redirects to their website instead of the editable html we had before